### PR TITLE
Added mocked implementation for use in unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ import "github.com/dukex/mixpanel"
 Track
 
 ``` go
-res, err := client.Track("13793", "Signed Up", map[string]interface{}{
-    "Referred By": "Friend",
+err := client.Track("13793", "Signed Up", map[string]interface{}{
+	"Referred By": "Friend",
 })
 ```
 --
@@ -32,14 +32,14 @@ Identify and Update Operation
 ``` go
 people := client.Identify("13793")
 
-res, err := people.Track(map[string]interface{}{
-  "Buy": "133"
+err := people.Track(map[string]interface{}{
+	"Buy": "133"
 })
 
-res, err := people.Update("$set", map[string]interface{}{
-  "Address":  "1313 Mockingbird Lane",
-  "Birthday": "1948-01-01",
-  })
+err := people.Update("$set", map[string]interface{}{
+	"Address":  "1313 Mockingbird Lane",
+	"Birthday": "1948-01-01",
+})
 ```
 
 ## License

--- a/example_test.go
+++ b/example_test.go
@@ -4,27 +4,21 @@ import (
 	"time"
 )
 
-func ExampleNewMixpanel() {
-	NewMixpanel("mytoken")
+func ExampleNew() {
+	New("mytoken", "")
 }
 
-func ExampleMixpanel_Identify() {
-	client := NewMixpanel("mytoken")
-
-	client.Identify("1")
-}
-
-func ExampleTrack() {
-	client := NewMixpanel("mytoken")
+func ExampleMixpanel() {
+	client := New("mytoken", "")
 
 	client.Track("1", "Sign Up", map[string]interface{}{
 		"from": "email",
 	})
 }
 
-func ExamplePeople_Update() {
-	var people *People
-	client := NewMixpanel("mytoken")
+func ExamplePeople() {
+	var people People
+	client := New("mytoken", "")
 
 	people = client.Identify("1")
 	people.Update("$set", map[string]interface{}{
@@ -33,13 +27,7 @@ func ExamplePeople_Update() {
 		"$created":     time.Now().String(),
 		"custom_field": "cool!",
 	})
-}
 
-func ExamplePeople_Track() {
-	var people *People
-	client := NewMixpanel("mytoken")
-
-	people = client.Identify("1")
 	people.Track("Sign Up", map[string]interface{}{
 		"from": "email",
 	})

--- a/example_test.go
+++ b/example_test.go
@@ -1,8 +1,6 @@
 package mixpanel
 
-import (
-	"time"
-)
+import "time"
 
 func ExampleNew() {
 	New("mytoken", "")
@@ -11,24 +9,29 @@ func ExampleNew() {
 func ExampleMixpanel() {
 	client := New("mytoken", "")
 
-	client.Track("1", "Sign Up", map[string]interface{}{
-		"from": "email",
+	client.Track("1", "Sign Up", &Event{
+		Properties: map[string]interface{}{
+			"from": "email",
+		},
 	})
 }
 
 func ExamplePeople() {
-	var people People
 	client := New("mytoken", "")
 
-	people = client.Identify("1")
-	people.Update("$set", map[string]interface{}{
-		"$email":       "user@email.com",
-		"$last_login":  time.Now(),
-		"$created":     time.Now().String(),
-		"custom_field": "cool!",
+	client.Update("1", &Update{
+		Operation: "$set",
+		Properties: map[string]interface{}{
+			"$email":       "user@email.com",
+			"$last_login":  time.Now(),
+			"$created":     time.Now().String(),
+			"custom_field": "cool!",
+		},
 	})
 
-	people.Track("Sign Up", map[string]interface{}{
-		"from": "email",
+	client.Track("1", "Sign Up", &Event{
+		Properties: map[string]interface{}{
+			"from": "email",
+		},
 	})
 }

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -7,19 +7,22 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 var (
 	ErrTrackFailed = errors.New("Mixpanel did not return 1 when tracking")
+
+	IgnoreTime *time.Time = &time.Time{}
 )
 
 // The Mixapanel struct store the mixpanel endpoint and the project token
 type Mixpanel interface {
-	// Track create a events to current distinct id
-	Track(distinctId string, eventName string, properties map[string]interface{}) error
+	// Create a mixpanel event
+	Track(distinctId, eventName string, e *Event) error
 
-	// Identify call mixpanel 'engage' and returns People instance
-	Identify(id string) People
+	// Set properties for a mixpanel user.
+	Update(distinctId string, u *Update) error
 }
 
 // The Mixapanel struct store the mixpanel endpoint and the project token
@@ -29,63 +32,81 @@ type mixpanel struct {
 	ApiURL string
 }
 
-// People represents a consumer, and is used on People Analytics
-type People interface {
-	// Track create a events to current people
-	Track(eventName string, properties map[string]interface{}) error
+// A mixpanel event
+type Event struct {
+	// IP-address of the user. Leave empty to use autodetect, or set to "0" to
+	// not specify an ip-address.
+	IP string
 
-	// Create a Update Operation to current people, see
-	// https://mixpanel.com/help/reference/http
-	Update(operation string, updateParams map[string]interface{}) error
+	// Timestamp. Set to nil to use the current time.
+	Timestamp *time.Time
+
+	// Custom properties. At least one must be specified.
+	Properties map[string]interface{}
 }
 
-// People represents a consumer, and is used on People Analytics
-type people struct {
-	m  *mixpanel
-	id string
-}
+// An update of a user in mixpanel
+type Update struct {
+	// IP-address of the user. Leave empty to use autodetect, or set to "0" to
+	// not specify an ip-address at all.
+	IP string
 
-type trackParams struct {
-	Event      string                 `json:"event"`
-	Properties map[string]interface{} `json:"properties"`
+	// Timestamp. Set to nil to use the current time, or IgnoreTime to not use a
+	// timestamp.
+	Timestamp *time.Time
+
+	// Update operation such as "$set", "$update" etc.
+	Operation string
+
+	// Custom properties. At least one must be specified.
+	Properties map[string]interface{}
 }
 
 // Track create a events to current distinct id
-func (m *mixpanel) Track(distinctId string, eventName string, properties map[string]interface{}) error {
-	params := trackParams{Event: eventName}
+func (m *mixpanel) Track(distinctId, eventName string, e *Event) error {
+	props := map[string]interface{}{
+		"token":       m.Token,
+		"distinct_id": distinctId,
+	}
+	if e.IP != "" {
+		props["ip"] = e.IP
+	}
+	if e.Timestamp != nil {
+		props["time"] = e.Timestamp.Unix()
+	}
 
-	params.Properties = make(map[string]interface{}, 0)
-	params.Properties["token"] = m.Token
-	params.Properties["distinct_id"] = distinctId
+	for key, value := range e.Properties {
+		props[key] = value
+	}
 
-	for key, value := range properties {
-		params.Properties[key] = value
+	params := map[string]interface{}{
+		"event":      eventName,
+		"properties": props,
 	}
 
 	return m.send("track", params)
 }
 
-// Identify call mixpanel 'engage' and returns People instance
-func (m *mixpanel) Identify(id string) People {
-	params := map[string]interface{}{"$token": m.Token, "$distinct_id": id}
-	m.send("engage", params)
-	return &people{m: m, id: id}
-}
-
-// Track create a events to current people
-func (p *people) Track(eventName string, properties map[string]interface{}) error {
-	return p.m.Track(p.id, eventName, properties)
-}
-
-// Create a Update Operation to current people, see
-// https://mixpanel.com/help/reference/http
-func (p *people) Update(operation string, updateParams map[string]interface{}) error {
+// Updates a user in mixpanel. See
+// https://mixpanel.com/help/reference/http#people-analytics-updates
+func (m *mixpanel) Update(distinctId string, u *Update) error {
 	params := map[string]interface{}{
-		"$token":       p.m.Token,
-		"$distinct_id": p.id,
+		"$token":       m.Token,
+		"$distinct_id": distinctId,
 	}
-	params[operation] = updateParams
-	return p.m.send("engage", params)
+
+	if u.IP != "" {
+		params["$ip"] = u.IP
+	}
+	if u.Timestamp == IgnoreTime {
+		params["$ignore_time"] = true
+	} else if u.Timestamp != nil {
+		params["$time"] = u.Timestamp.Unix()
+	}
+
+	params[u.Operation] = u.Properties
+
+	return m.send("engage", params)
 }
 
 func (m *mixpanel) to64(data string) string {

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -24,6 +24,7 @@ type Mixpanel interface {
 
 // The Mixapanel struct store the mixpanel endpoint and the project token
 type mixpanel struct {
+	Client *http.Client
 	Token  string
 	ApiURL string
 }
@@ -97,7 +98,7 @@ func (m *mixpanel) send(eventType string, params interface{}) error {
 	data := string(dataJSON)
 
 	url := m.ApiURL + "/" + eventType + "?data=" + m.to64(data)
-	if resp, err := http.Get(url); err != nil {
+	if resp, err := m.Client.Get(url); err != nil {
 		return fmt.Errorf("mixpanel: %s", err.Error())
 	} else {
 		defer resp.Body.Close()
@@ -116,11 +117,18 @@ func (m *mixpanel) send(eventType string, params interface{}) error {
 // New returns the client instance. If apiURL is blank, the default will be used
 // ("https://api.mixpanel.com").
 func New(token, apiURL string) Mixpanel {
+	return NewFromClient(http.DefaultClient, token, apiURL)
+}
+
+// Creates a client instance using the specified client instance. This is useful
+// when using a proxy.
+func NewFromClient(c *http.Client, token, apiURL string) Mixpanel {
 	if apiURL == "" {
 		apiURL = "https://api.mixpanel.com"
 	}
 
 	return &mixpanel{
+		Client: c,
 		Token:  token,
 		ApiURL: apiURL,
 	}

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -18,6 +18,7 @@ var (
 func setup() {
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
+		w.Write([]byte("1\n"))
 		LastRequest = r
 	}))
 
@@ -130,5 +131,23 @@ func TestPeopleTrack(t *testing.T) {
 	if !reflect.DeepEqual(path, want) {
 		t.Errorf("path returned %+v, want %+v",
 			path, want)
+	}
+}
+
+func TestError(t *testing.T) {
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("0\n"))
+		LastRequest = r
+	}))
+
+	client = New("e3bc4100330c35722740fb8c6f5abddc", ts.URL)
+
+	if err := client.Track("1", "name", nil); err != ErrTrackFailed {
+		t.Error("Got bad error for track", err)
+	}
+
+	if err := client.Identify("1").Track("name", nil); err != ErrTrackFailed {
+		t.Error("Got bad error for track", err)
 	}
 }

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -41,8 +41,10 @@ func TestTrack(t *testing.T) {
 	setup()
 	defer teardown()
 
-	client.Track("13793", "Signed Up", map[string]interface{}{
-		"Referred By": "Friend",
+	client.Track("13793", "Signed Up", &Event{
+		Properties: map[string]interface{}{
+			"Referred By": "Friend",
+		},
 	})
 
 	want := "{\"event\":\"Signed Up\",\"properties\":{\"Referred By\":\"Friend\",\"distinct_id\":\"13793\",\"token\":\"e3bc4100330c35722740fb8c6f5abddc\"}}"
@@ -61,36 +63,16 @@ func TestTrack(t *testing.T) {
 	}
 }
 
-func TestIdentify(t *testing.T) {
-	setup()
-	defer teardown()
-
-	client.Identify("13793")
-
-	want := "{\"$distinct_id\":\"13793\",\"$token\":\"e3bc4100330c35722740fb8c6f5abddc\"}"
-
-	if !reflect.DeepEqual(decodeURL(LastRequest.URL.String()), want) {
-		t.Errorf("LastRequest.URL returned %+v, want %+v",
-			decodeURL(LastRequest.URL.String()), want)
-	}
-
-	want = "/engage"
-	path := LastRequest.URL.Path
-
-	if !reflect.DeepEqual(path, want) {
-		t.Errorf("path returned %+v, want %+v",
-			path, want)
-	}
-}
-
 func TestPeopleOperations(t *testing.T) {
 	setup()
 	defer teardown()
 
-	people := client.Identify("13793")
-	people.Update("$set", map[string]interface{}{
-		"Address":  "1313 Mockingbird Lane",
-		"Birthday": "1948-01-01",
+	client.Update("13793", &Update{
+		Operation: "$set",
+		Properties: map[string]interface{}{
+			"Address":  "1313 Mockingbird Lane",
+			"Birthday": "1948-01-01",
+		},
 	})
 
 	want := "{\"$distinct_id\":\"13793\",\"$set\":{\"Address\":\"1313 Mockingbird Lane\",\"Birthday\":\"1948-01-01\"},\"$token\":\"e3bc4100330c35722740fb8c6f5abddc\"}"
@@ -113,9 +95,10 @@ func TestPeopleTrack(t *testing.T) {
 	setup()
 	defer teardown()
 
-	people := client.Identify("13793")
-	people.Track("Signed Up", map[string]interface{}{
-		"Referred By": "Friend",
+	client.Track("13793", "Signed Up", &Event{
+		Properties: map[string]interface{}{
+			"Referred By": "Friend",
+		},
 	})
 
 	want := "{\"event\":\"Signed Up\",\"properties\":{\"Referred By\":\"Friend\",\"distinct_id\":\"13793\",\"token\":\"e3bc4100330c35722740fb8c6f5abddc\"}}"
@@ -143,11 +126,11 @@ func TestError(t *testing.T) {
 
 	client = New("e3bc4100330c35722740fb8c6f5abddc", ts.URL)
 
-	if err := client.Track("1", "name", nil); err != ErrTrackFailed {
+	if err := client.Update("1", &Update{}); err != ErrTrackFailed {
 		t.Error("Got bad error for track", err)
 	}
 
-	if err := client.Identify("1").Track("name", nil); err != ErrTrackFailed {
+	if err := client.Track("1", "name", &Event{}); err != ErrTrackFailed {
 		t.Error("Got bad error for track", err)
 	}
 }

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	ts          *httptest.Server
-	client      *Mixpanel
+	client      Mixpanel
 	LastRequest *http.Request
 )
 
@@ -21,8 +21,7 @@ func setup() {
 		LastRequest = r
 	}))
 
-	client = NewMixpanel("e3bc4100330c35722740fb8c6f5abddc")
-	client.ApiURL = ts.URL
+	client = New("e3bc4100330c35722740fb8c6f5abddc", ts.URL)
 }
 
 func teardown() {

--- a/mock.go
+++ b/mock.go
@@ -1,0 +1,87 @@
+package mixpanel
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Mocked version of Mixpanel which can be used in unit tests.
+type Mock struct {
+	// All People identified, mapped by distinctId
+	People map[string]*MockPeople
+}
+
+func NewMock() *Mock {
+	return &Mock{
+		People: map[string]*MockPeople{},
+	}
+}
+
+func (m *Mock) String() string {
+	str := ""
+	for id, p := range m.People {
+		str += id + ":\n" + p.String()
+	}
+	return str
+}
+
+// Identifies a user. The user will be added to the People map.
+func (m *Mock) Identify(distinctId string) People {
+	if p, ok := m.People[distinctId]; ok {
+		return p
+	} else {
+		p := &MockPeople{
+			Properties: map[string]interface{}{},
+		}
+		m.People[distinctId] = p
+		return p
+	}
+}
+
+func (m *Mock) Track(distinctId string, eventName string, properties map[string]interface{}) error {
+	return m.Identify(distinctId).Track(eventName, properties)
+}
+
+type MockPeople struct {
+	Properties map[string]interface{}
+	Events     []MockEvent
+}
+
+func (mp *MockPeople) String() string {
+	str := ""
+	str += "  properties:\n"
+	for key, val := range mp.Properties {
+		str += fmt.Sprintf("    %s: %v\n", key, val)
+	}
+	str += "  events:\n"
+	for _, event := range mp.Events {
+		str += "    " + event.Name + ":\n"
+		for key, val := range event.Properties {
+			str += fmt.Sprintf("      %s: %v\n", key, val)
+		}
+	}
+	return str
+}
+
+func (mp *MockPeople) Track(eventName string, properties map[string]interface{}) error {
+	mp.Events = append(mp.Events, MockEvent{eventName, properties})
+	return nil
+}
+
+func (mp *MockPeople) Update(operation string, updateParams map[string]interface{}) error {
+	switch operation {
+	case "$set":
+		for key, val := range updateParams {
+			mp.Properties[key] = val
+		}
+	default:
+		return errors.New("mixpanel.Mock only supports the $set operation")
+	}
+
+	return nil
+}
+
+type MockEvent struct {
+	Name       string
+	Properties map[string]interface{}
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,29 +1,44 @@
 package mixpanel
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 var fullfillsInterface Mixpanel = &Mock{}
 
 func ExampleMock() {
-	var people People
 	client := NewMock()
 
-	people = client.Identify("1")
-	people.Update("$set", map[string]interface{}{
-		"custom_field": "cool!",
+	t, _ := time.Parse(time.RFC3339, "2016-03-03T15:17:53+01:00")
+
+	client.Update("1", &Update{
+		Operation: "$set",
+		Timestamp: &t,
+		IP:        "127.0.0.1",
+		Properties: map[string]interface{}{
+			"custom_field": "cool!",
+		},
 	})
 
-	people.Track("Sign Up", map[string]interface{}{
-		"from": "email",
+	client.Track("1", "Sign Up", &Event{
+		IP: "1.2.3.4",
+		Properties: map[string]interface{}{
+			"from": "email",
+		},
 	})
 
 	fmt.Println(client)
 
 	// Output:
 	// 1:
+	//   ip: 127.0.0.1
+	//   time: 2016-03-03T15:17:53+01:00
 	//   properties:
 	//     custom_field: cool!
 	//   events:
 	//     Sign Up:
+	//       IP: 1.2.3.4
+	//       Timestamp:
 	//       from: email
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,0 +1,29 @@
+package mixpanel
+
+import "fmt"
+
+var fullfillsInterface Mixpanel = &Mock{}
+
+func ExampleMock() {
+	var people People
+	client := NewMock()
+
+	people = client.Identify("1")
+	people.Update("$set", map[string]interface{}{
+		"custom_field": "cool!",
+	})
+
+	people.Track("Sign Up", map[string]interface{}{
+		"from": "email",
+	})
+
+	fmt.Println(client)
+
+	// Output:
+	// 1:
+	//   properties:
+	//     custom_field: cool!
+	//   events:
+	//     Sign Up:
+	//       from: email
+}


### PR DESCRIPTION
Hi!

I've changed the `Mixpanel` struct to be an interface and added a mock implementation in addition to the current real implementation. This makes it easy to test code which uses mixpanel:

``` go
var client mixpanel.Mixpanel = mixpanel.NewMock()

people = client.Identify("1")
people.Update("$set", map[string]interface{}{
    "custom_field": "cool!",
})

// client.People now holds the tracked data
```

Also, functions now only return a single error and not an HTTP response, making error handling easier.
