### PR TITLE
Add plumbing to allow autogeolocation on the mixpanel side

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -106,6 +106,10 @@ func (m *Mock) Update(distinctId string, u *Update) error {
 	return nil
 }
 
+func (m *Mock) Alias(distinctId, newId string) error {
+	return nil
+}
+
 type MockEvent struct {
 	Event
 	Name string


### PR DESCRIPTION
In short, empty Event.IP/Update.IP results in a  ip=1 to be appended to the url params for people updates and events. By sending ip=1, mixpanel will automatically geolocate using the ip of the requester during the API request.

---

It looks like this was the intended behavior, but unfortunately it did not work as described (https://github.com/dukex/mixpanel/blob/master/mixpanel.go#L39-L40)