### PR TITLE
Add Import method to be able to create events older than 5 days

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,11 +3,15 @@ package mixpanel
 import "time"
 
 func ExampleNew() {
-	New("mytoken", "myapisecret", "")
+	New("mytoken", "")
+}
+
+func ExampleNewWithSecret() {
+	NewWithSecret("mytoken", "myapisecret", "")
 }
 
 func ExampleMixpanel() {
-	client := New("mytoken", "myapisecret", "")
+	client := New("mytoken", "")
 
 	client.Track("1", "Sign Up", &Event{
 		Properties: map[string]interface{}{
@@ -17,7 +21,7 @@ func ExampleMixpanel() {
 }
 
 func ExamplePeople() {
-	client := New("mytoken", "myapisecret", "")
+	client := NewWithSecret("mytoken", "myapisecret", "")
 
 	client.Update("1", &Update{
 		Operation: "$set",

--- a/example_test.go
+++ b/example_test.go
@@ -3,11 +3,11 @@ package mixpanel
 import "time"
 
 func ExampleNew() {
-	New("mytoken", "")
+	New("mytoken", "myapisecret", "")
 }
 
 func ExampleMixpanel() {
-	client := New("mytoken", "")
+	client := New("mytoken", "myapisecret", "")
 
 	client.Track("1", "Sign Up", &Event{
 		Properties: map[string]interface{}{
@@ -17,7 +17,7 @@ func ExampleMixpanel() {
 }
 
 func ExamplePeople() {
-	client := New("mytoken", "")
+	client := New("mytoken", "myapisecret", "")
 
 	client.Update("1", &Update{
 		Operation: "$set",
@@ -32,6 +32,14 @@ func ExamplePeople() {
 	client.Track("1", "Sign Up", &Event{
 		Properties: map[string]interface{}{
 			"from": "email",
+		},
+	})
+
+	importTimestamp := time.Now().Add(-5 * 24 * time.Hour)
+	client.Import("1", "Sign Up", &Event{
+		Timestamp: &importTimestamp,
+		Properties: map[string]interface{}{
+			"subject": "topic",
 		},
 	})
 }

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -128,20 +128,18 @@ func (m *mixpanel) Track(distinctId, eventName string, e *Event) error {
 	return m.send("track", params, autoGeolocate)
 }
 
-// Import create an event for an existing distinct id, even if the event is older than 5 days.
+// Import create an event for an existing distinct id
 // See https://developer.mixpanel.com/docs/importing-old-events
 func (m *mixpanel) Import(distinctId, eventName string, e *Event) error {
-	if e.Timestamp == nil || time.Since(*e.Timestamp) < 5*24*time.Hour {
-		return m.Track(distinctId, eventName, e)
-	}
-
 	props := map[string]interface{}{
 		"token":       m.Token,
 		"distinct_id": distinctId,
-		"time":        e.Timestamp.Unix(),
 	}
 	if e.IP != "" {
 		props["ip"] = e.IP
+	}
+	if e.Timestamp != nil {
+		props["time"] = e.Timestamp.Unix()
 	}
 
 	for key, value := range e.Properties {

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -41,6 +41,7 @@ type Mixpanel interface {
 	// Set properties for a mixpanel user.
 	Update(distinctId string, u *Update) error
 
+	// Create an alias for an existing distinct id
 	Alias(distinctId, newId string) error
 }
 
@@ -81,7 +82,7 @@ type Update struct {
 	Properties map[string]interface{}
 }
 
-// Track create a events to current distinct id
+// Alias create an alias for an existing distinct id
 func (m *mixpanel) Alias(distinctId, newId string) error {
 	props := map[string]interface{}{
 		"token":       m.Token,
@@ -97,7 +98,7 @@ func (m *mixpanel) Alias(distinctId, newId string) error {
 	return m.send("track", params, false)
 }
 
-// Track create a events to current distinct id
+// Track create an event for an existing distinct id
 func (m *mixpanel) Track(distinctId, eventName string, e *Event) error {
 	props := map[string]interface{}{
 		"token":       m.Token,
@@ -124,7 +125,7 @@ func (m *mixpanel) Track(distinctId, eventName string, e *Event) error {
 	return m.send("track", params, autoGeolocate)
 }
 
-// Updates a user in mixpanel. See
+// Update updates a user in mixpanel. See
 // https://mixpanel.com/help/reference/http#people-analytics-updates
 func (m *mixpanel) Update(distinctId string, u *Update) error {
 	params := map[string]interface{}{

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -228,7 +228,8 @@ func (m *mixpanel) send(eventType string, params interface{}, autoGeolocate bool
 	json.Unmarshal(body, &jsonBody)
 
 	if jsonBody.Status != 1 {
-		return wrapErr(&ErrTrackFailed{Message: jsonBody.Error})
+		errMsg := fmt.Sprintf("error=%s; status=%d; httpCode=%d", jsonBody.Error, jsonBody.Status, resp.StatusCode)
+		return wrapErr(&ErrTrackFailed{Message: errMsg})
 	}
 
 	return nil

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -236,13 +236,24 @@ func (m *mixpanel) send(eventType string, params interface{}, autoGeolocate bool
 
 // New returns the client instance. If apiURL is blank, the default will be used
 // ("https://api.mixpanel.com").
-func New(token, secret, apiURL string) Mixpanel {
-	return NewFromClient(http.DefaultClient, token, secret, apiURL)
+func New(token, apiURL string) Mixpanel {
+	return NewFromClient(http.DefaultClient, token, apiURL)
 }
 
-// Creates a client instance using the specified client instance. This is useful
+// NewWithSecret returns the client instance using a secret.If apiURL is blank,
+// the default will be used ("https://api.mixpanel.com").
+func NewWithSecret(token, secret, apiURL string) Mixpanel {
+	return NewFromClientWithSecret(http.DefaultClient, token, secret, apiURL)
+}
+
+// NewFromClient creates a client instance using the specified client instance. This is useful
 // when using a proxy.
-func NewFromClient(c *http.Client, token, secret, apiURL string) Mixpanel {
+func NewFromClient(c *http.Client, token, apiURL string) Mixpanel {
+	return NewFromClientWithSecret(c, token, "", apiURL)
+}
+
+// NewFromClientWithSecret creates a client instance using the specified client instance and secret.
+func NewFromClientWithSecret(c *http.Client, token, secret, apiURL string) Mixpanel {
 	if apiURL == "" {
 		apiURL = "https://api.mixpanel.com"
 	}

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -48,6 +48,7 @@ type Mixpanel interface {
 type mixpanel struct {
 	Client *http.Client
 	Token  string
+	Secret string
 	ApiURL string
 }
 
@@ -169,7 +170,9 @@ func (m *mixpanel) send(eventType string, params interface{}, autoGeolocate bool
 		return &MixpanelError{URL: url, Err: err}
 	}
 
-	resp, err := m.Client.Get(url)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.SetBasicAuth(m.Secret, "")
+	resp, err := m.Client.Do(req)
 
 	if err != nil {
 		return wrapErr(err)
@@ -200,13 +203,13 @@ func (m *mixpanel) send(eventType string, params interface{}, autoGeolocate bool
 
 // New returns the client instance. If apiURL is blank, the default will be used
 // ("https://api.mixpanel.com").
-func New(token, apiURL string) Mixpanel {
-	return NewFromClient(http.DefaultClient, token, apiURL)
+func New(token, secret, apiURL string) Mixpanel {
+	return NewFromClient(http.DefaultClient, token, secret, apiURL)
 }
 
 // Creates a client instance using the specified client instance. This is useful
 // when using a proxy.
-func NewFromClient(c *http.Client, token, apiURL string) Mixpanel {
+func NewFromClient(c *http.Client, token, secret, apiURL string) Mixpanel {
 	if apiURL == "" {
 		apiURL = "https://api.mixpanel.com"
 	}
@@ -214,6 +217,7 @@ func NewFromClient(c *http.Client, token, apiURL string) Mixpanel {
 	return &mixpanel{
 		Client: c,
 		Token:  token,
+		Secret: secret,
 		ApiURL: apiURL,
 	}
 }

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -29,15 +29,15 @@ type ErrTrackFailed struct {
 }
 
 func (err *ErrTrackFailed) Error() string {
-	return fmt.Sprintf("Mixpanel did not return 1 when tracking: %s", err.Message)
+	return fmt.Sprintf("mixpanel did not return 1 when tracking: %s", err.Message)
 }
 
 // The Mixapanel struct store the mixpanel endpoint and the project token
 type Mixpanel interface {
-	// Create a mixpanel event
+	// Create a mixpanel event using the track api
 	Track(distinctId, eventName string, e *Event) error
 
-	// Create a mixpanel event, even if it's older than 5 days
+	// Create a mixpanel event using the import api
 	Import(distinctId, eventName string, e *Event) error
 
 	// Set properties for a mixpanel user.

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -204,7 +204,9 @@ func (m *mixpanel) send(eventType string, params interface{}, autoGeolocate bool
 	}
 
 	req, _ := http.NewRequest("GET", url, nil)
-	req.SetBasicAuth(m.Secret, "")
+	if m.Secret != "" {
+		req.SetBasicAuth(m.Secret, "")
+	}
 	resp, err := m.Client.Do(req)
 
 	if err != nil {

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -2,11 +2,13 @@ package mixpanel
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 var (
@@ -60,6 +62,65 @@ func TestTrack(t *testing.T) {
 	if !reflect.DeepEqual(path, want) {
 		t.Errorf("path returned %+v, want %+v",
 			path, want)
+	}
+}
+
+func TestImport(t *testing.T) {
+	setup()
+	defer teardown()
+
+	eventBase := &Event{
+		Properties: map[string]interface{}{
+			"Referred By": "Friend",
+		},
+	}
+
+	trackTime := time.Now().Add(-4 * 24 * time.Hour)
+	importTime := time.Now().Add(-5 * 24 * time.Hour)
+
+	tests := []struct {
+		name             string
+		eventTimestamp   *time.Time
+		expectedEvent    string
+		expectedEndpoint string
+	}{
+		{
+			name: "no timestamp",
+			eventTimestamp: nil,
+			expectedEvent: "{\"event\":\"Signed Up\",\"properties\":{\"Referred By\":\"Friend\",\"distinct_id\":\"13793\",\"token\":\"e3bc4100330c35722740fb8c6f5abddc\"}}",
+			expectedEndpoint: "/track",
+		},
+		{
+			name:       "timestamp not older than 5 days",
+			eventTimestamp: &trackTime,
+			expectedEvent: fmt.Sprintf("{\"event\":\"Signed Up\",\"properties\":{\"Referred By\":\"Friend\",\"distinct_id\":\"13793\",\"time\":%d,\"token\":\"e3bc4100330c35722740fb8c6f5abddc\"}}", trackTime.Unix()),
+			expectedEndpoint: "/track",
+		},
+		{
+			name:       "timestamp older than 5 days",
+			eventTimestamp: &importTime,
+			expectedEvent: fmt.Sprintf("{\"event\":\"Signed Up\",\"properties\":{\"Referred By\":\"Friend\",\"distinct_id\":\"13793\",\"time\":%d,\"token\":\"e3bc4100330c35722740fb8c6f5abddc\"}}", importTime.Unix()),
+			expectedEndpoint: "/import",
+		},
+	}
+
+	for _, item := range tests {
+		t.Run(item.name, func(t *testing.T) {
+			event := eventBase
+			event.Timestamp = item.eventTimestamp
+			client.Import("13793", "Signed Up", event)
+
+			if !reflect.DeepEqual(decodeURL(LastRequest.URL.String()), item.expectedEvent) {
+				t.Errorf("%s: LastRequest.URL returned %+v, want %+v",
+					item.name, decodeURL(LastRequest.URL.String()), item.expectedEvent)
+			}
+
+			path := LastRequest.URL.Path
+			if !reflect.DeepEqual(path, item.expectedEndpoint) {
+				t.Errorf("%s: path returned %+v, want %+v",
+					item.name, path, item.expectedEndpoint)
+			}
+		})
 	}
 }
 

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -24,7 +24,7 @@ func setup() {
 		LastRequest = r
 	}))
 
-	client = New("e3bc4100330c35722740fb8c6f5abddc", "bXlhcGlzZWNyZXQ=", ts.URL)
+	client = NewWithSecret("e3bc4100330c35722740fb8c6f5abddc", "mysecret", ts.URL)
 }
 
 func teardown() {
@@ -125,7 +125,7 @@ func TestUpdate(t *testing.T) {
 func TestError(t *testing.T) {
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		w.Write([]byte(`{"error": "api_key, missing or empty", "status": 0}`))
+		w.Write([]byte(`{"error": "some error", "status": 0}`))
 		LastRequest = r
 	}))
 
@@ -144,12 +144,12 @@ func TestError(t *testing.T) {
 			return
 		}
 
-		if terr.Message != "api_key, missing or empty" {
+		if terr.Message != "some error" {
 			t.Errorf("Wrong body carried in the *ErrTrackFailed: %q", terr.Message)
 		}
 	}
 
-	client = New("e3bc4100330c35722740fb8c6f5abddc", "", ts.URL)
+	client = New("e3bc4100330c35722740fb8c6f5abddc", ts.URL)
 
 	assertErrTrackFailed(client.Update("1", &Update{}))
 	assertErrTrackFailed(client.Track("1", "name", &Event{}))

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -22,7 +22,7 @@ func setup() {
 		LastRequest = r
 	}))
 
-	client = New("e3bc4100330c35722740fb8c6f5abddc", ts.URL)
+	client = New("e3bc4100330c35722740fb8c6f5abddc", "bXlhcGlzZWNyZXQ=", ts.URL)
 }
 
 func teardown() {
@@ -94,7 +94,7 @@ func TestUpdate(t *testing.T) {
 func TestError(t *testing.T) {
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
-		w.Write([]byte("0\n"))
+		w.Write([]byte(`{"error": "api_key, missing or empty", "status": 0}`))
 		LastRequest = r
 	}))
 
@@ -113,13 +113,14 @@ func TestError(t *testing.T) {
 			return
 		}
 
-		if terr.Body != "0\n" {
-			t.Errorf("Wrong body carried in the *ErrTrackFailed: %q", terr.Body)
+		if terr.Message != "api_key, missing or empty" {
+			t.Errorf("Wrong body carried in the *ErrTrackFailed: %q", terr.Message)
 		}
 	}
 
-	client = New("e3bc4100330c35722740fb8c6f5abddc", ts.URL)
+	client = New("e3bc4100330c35722740fb8c6f5abddc", "", ts.URL)
 
 	assertErrTrackFailed(client.Update("1", &Update{}))
 	assertErrTrackFailed(client.Track("1", "name", &Event{}))
+	assertErrTrackFailed(client.Import("1", "name", &Event{}))
 }

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -91,32 +91,6 @@ func TestPeopleOperations(t *testing.T) {
 	}
 }
 
-func TestPeopleTrack(t *testing.T) {
-	setup()
-	defer teardown()
-
-	client.Track("13793", "Signed Up", &Event{
-		Properties: map[string]interface{}{
-			"Referred By": "Friend",
-		},
-	})
-
-	want := "{\"event\":\"Signed Up\",\"properties\":{\"Referred By\":\"Friend\",\"distinct_id\":\"13793\",\"token\":\"e3bc4100330c35722740fb8c6f5abddc\"}}"
-
-	if !reflect.DeepEqual(decodeURL(LastRequest.URL.String()), want) {
-		t.Errorf("LastRequest.URL returned %+v, want %+v",
-			decodeURL(LastRequest.URL.String()), want)
-	}
-
-	want = "/track"
-	path := LastRequest.URL.Path
-
-	if !reflect.DeepEqual(path, want) {
-		t.Errorf("path returned %+v, want %+v",
-			path, want)
-	}
-}
-
 func TestError(t *testing.T) {
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -63,7 +63,7 @@ func TestTrack(t *testing.T) {
 	}
 }
 
-func TestPeopleOperations(t *testing.T) {
+func TestUpdate(t *testing.T) {
 	setup()
 	defer teardown()
 

--- a/mock.go
+++ b/mock.go
@@ -104,12 +104,12 @@ func (m *Mock) Update(distinctId string, u *Update) error {
 	}
 
 	switch u.Operation {
-	case "$set":
+	case "$set", "$set_once":
 		for key, val := range u.Properties {
 			p.Properties[key] = val
 		}
 	default:
-		return errors.New("mixpanel.Mock only supports the $set operation")
+		return errors.New("mixpanel.Mock only supports the $set and $set_once operations")
 	}
 
 	return nil

--- a/mock.go
+++ b/mock.go
@@ -48,6 +48,15 @@ func (m *Mock) Track(distinctId, eventName string, e *Event) error {
 	return nil
 }
 
+func (m *Mock) Import(distinctId, eventName string, e *Event) error {
+	p := m.people(distinctId)
+	p.Events = append(p.Events, MockEvent{
+		Event: *e,
+		Name:  eventName,
+	})
+	return nil
+}
+
 type MockPeople struct {
 	Properties map[string]interface{}
 	Time       *time.Time

--- a/mock_test.go
+++ b/mock_test.go
@@ -28,6 +28,14 @@ func ExampleMock() {
 		},
 	})
 
+	client.Import("1", "Sign Up", &Event{
+		IP: "1.2.3.4",
+		Timestamp: &t,
+		Properties: map[string]interface{}{
+			"imported": true,
+		},
+	})
+
 	fmt.Println(client)
 
 	// Output:
@@ -41,4 +49,9 @@ func ExampleMock() {
 	//       IP: 1.2.3.4
 	//       Timestamp:
 	//       from: email
+	//     Sign Up:
+	//       IP: 1.2.3.4
+	//       Timestamp: 2016-03-03T15:17:53+01:00
+	//       imported: true
+
 }


### PR DESCRIPTION
The main new feature is to be able to create events older than 5 days. In order to do this, basic HTTP auth has also been added (without password as it is not required to use Import). Some other small fixes were implemented too.
Mixpanel docs: https://developer.mixpanel.com/docs/importing-old-events