### PR TITLE
Implement UpdateGroup endpoint

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -19,7 +19,7 @@ func ExampleMixpanel() {
 func ExamplePeople() {
 	client := New("mytoken", "")
 
-	client.Update("1", &Update{
+	client.UpdateUser("1", &Update{
 		Operation: "$set",
 		Properties: map[string]interface{}{
 			"$email":       "user@email.com",

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -39,7 +39,14 @@ type Mixpanel interface {
 	Track(distinctId, eventName string, e *Event) error
 
 	// Set properties for a mixpanel user.
+	// Deprecated: Use UpdateUser instead
 	Update(distinctId string, u *Update) error
+
+	// Set properties for a mixpanel user.
+	UpdateUser(distinctId string, u *Update) error
+
+	// Set properties for a mixpanel group.
+	UpdateGroup(groupKey, groupId string, u *Update) error
 
 	Alias(distinctId, newId string) error
 }
@@ -124,9 +131,14 @@ func (m *mixpanel) Track(distinctId, eventName string, e *Event) error {
 	return m.send("track", params, autoGeolocate)
 }
 
-// Updates a user in mixpanel. See
-// https://mixpanel.com/help/reference/http#people-analytics-updates
+// Deprecated: Use UpdateUser instead
 func (m *mixpanel) Update(distinctId string, u *Update) error {
+	return m.UpdateUser(distinctId, u)
+}
+
+// UpdateUser: Updates a user in mixpanel. See
+// https://mixpanel.com/help/reference/http#people-analytics-updates
+func (m *mixpanel) UpdateUser(distinctId string, u *Update) error {
 	params := map[string]interface{}{
 		"$token":       m.Token,
 		"$distinct_id": distinctId,

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -160,6 +160,20 @@ func (m *mixpanel) UpdateUser(distinctId string, u *Update) error {
 	return m.send("engage", params, autoGeolocate)
 }
 
+// UpdateUser: Updates a group in mixpanel. See
+// https://api.mixpanel.com/groups#group-set
+func (m *mixpanel) UpdateGroup(groupKey, groupId string, u *Update) error {
+	params := map[string]interface{}{
+		"$token":     m.Token,
+		"$group_id":  groupId,
+		"$group_key": groupKey,
+	}
+
+	params[u.Operation] = u.Properties
+
+	return m.send("groups", params, false)
+}
+
 func (m *mixpanel) to64(data []byte) string {
 	return base64.StdEncoding.EncodeToString(data)
 }

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -160,7 +160,7 @@ func (m *mixpanel) UpdateUser(distinctId string, u *Update) error {
 	return m.send("engage", params, autoGeolocate)
 }
 
-// UpdateUser: Updates a group in mixpanel. See
+// UpdateGroup: Updates a group in mixpanel. See
 // https://api.mixpanel.com/groups#group-set
 func (m *mixpanel) UpdateGroup(groupKey, groupId string, u *Update) error {
 	params := map[string]interface{}{

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -91,6 +91,34 @@ func TestPeopleOperations(t *testing.T) {
 	}
 }
 
+func TestGroupOperations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	client.UpdateGroup("company_id", "11", &Update{
+		Operation: "$set",
+		Properties: map[string]interface{}{
+			"Address":  "1313 Mockingbird Lane",
+			"Birthday": "1948-01-01",
+		},
+	})
+
+	want := "{\"$group_id\":\"11\",\"$group_key\":\"company_id\",\"$set\":{\"Address\":\"1313 Mockingbird Lane\",\"Birthday\":\"1948-01-01\"},\"$token\":\"e3bc4100330c35722740fb8c6f5abddc\"}"
+
+	if !reflect.DeepEqual(decodeURL(LastRequest.URL.String()), want) {
+		t.Errorf("LastRequest.URL returned %+v, want %+v",
+			decodeURL(LastRequest.URL.String()), want)
+	}
+
+	want = "/groups"
+	path := LastRequest.URL.Path
+
+	if !reflect.DeepEqual(path, want) {
+		t.Errorf("path returned %+v, want %+v",
+			path, want)
+	}
+}
+
 func TestPeopleTrack(t *testing.T) {
 	setup()
 	defer teardown()

--- a/mock.go
+++ b/mock.go
@@ -85,6 +85,10 @@ func (mp *MockPeople) String() string {
 }
 
 func (m *Mock) Update(distinctId string, u *Update) error {
+	return m.UpdateUser(distinctId, u)
+}
+
+func (m *Mock) UpdateUser(distinctId string, u *Update) error {
 	p := m.people(distinctId)
 
 	if u.IP != "" {
@@ -103,6 +107,10 @@ func (m *Mock) Update(distinctId string, u *Update) error {
 		return errors.New("mixpanel.Mock only supports the $set operation")
 	}
 
+	return nil
+}
+
+func (m *Mock) UpdateGroup(groupKey, groupUser string, u *Update) error {
 	return nil
 }
 


### PR DESCRIPTION
Some time ago mixpanel released a new feature called "groups" (checkout: https://developer.mixpanel.com/reference/group-set-property). This PR add the ability to update such entity via this client.

In order to avoid confusion in between the mutation of Users and Groups, i deprecated the `Update` endpoint and renamed it `UpdateUser`.