### PR TITLE
Use context in all http requests

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,9 @@
 package mixpanel
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 func ExampleNew() {
 	New("mytoken", "")
@@ -13,7 +16,7 @@ func ExampleNewWithSecret() {
 func ExampleMixpanel() {
 	client := New("mytoken", "")
 
-	client.Track("1", "Sign Up", &Event{
+	client.Track(context.TODO(), "1", "Sign Up", &Event{
 		Properties: map[string]interface{}{
 			"from": "email",
 		},
@@ -23,7 +26,7 @@ func ExampleMixpanel() {
 func ExamplePeople() {
 	client := NewWithSecret("mytoken", "myapisecret", "")
 
-	client.UpdateUser("1", &Update{
+	client.UpdateUser(context.TODO(), "1", &Update{
 		Operation: "$set",
 		Properties: map[string]interface{}{
 			"$email":       "user@email.com",
@@ -33,14 +36,14 @@ func ExamplePeople() {
 		},
 	})
 
-	client.Track("1", "Sign Up", &Event{
+	client.Track(context.TODO(), "1", "Sign Up", &Event{
 		Properties: map[string]interface{}{
 			"from": "email",
 		},
 	})
 
 	importTimestamp := time.Now().Add(-5 * 24 * time.Hour)
-	client.Import("1", "Sign Up", &Event{
+	client.Import(context.TODO(), "1", "Sign Up", &Event{
 		Timestamp: &importTimestamp,
 		Properties: map[string]interface{}{
 			"subject": "topic",

--- a/mixpanel_test.go
+++ b/mixpanel_test.go
@@ -1,6 +1,7 @@
 package mixpanel
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -58,7 +59,7 @@ func TestTrack(t *testing.T) {
 	setup()
 	defer teardown()
 
-	client.Track("13793", "Signed Up", &Event{
+	client.Track(context.TODO(), "13793", "Signed Up", &Event{
 		Properties: map[string]interface{}{
 			"Referred By": "Friend",
 		},
@@ -76,7 +77,7 @@ func TestImport(t *testing.T) {
 
 	importTime := time.Now().Add(-5 * 24 * time.Hour)
 
-	client.Import("13793", "Signed Up", &Event{
+	client.Import(context.TODO(), "13793", "Signed Up", &Event{
 		Properties: map[string]interface{}{
 			"Referred By": "Friend",
 		},
@@ -93,7 +94,7 @@ func TestGroupOperations(t *testing.T) {
 	setup()
 	defer teardown()
 
-	client.UpdateGroup("company_id", "11", &Update{
+	client.UpdateGroup(context.TODO(), "company_id", "11", &Update{
 		Operation: "$set",
 		Properties: map[string]interface{}{
 			"Address":  "1313 Mockingbird Lane",
@@ -111,7 +112,7 @@ func TestUpdateUser(t *testing.T) {
 	setup()
 	defer teardown()
 
-	client.UpdateUser("13793", &Update{
+	client.UpdateUser(context.TODO(), "13793", &Update{
 		Operation: "$set",
 		Properties: map[string]interface{}{
 			"Address":  "1313 Mockingbird Lane",
@@ -152,7 +153,7 @@ func TestError(t *testing.T) {
 
 	client = New("e3bc4100330c35722740fb8c6f5abddc", ts.URL)
 
-	assertErrTrackFailed(client.UpdateUser("1", &Update{}))
-	assertErrTrackFailed(client.Track("1", "name", &Event{}))
-	assertErrTrackFailed(client.Import("1", "name", &Event{}))
+	assertErrTrackFailed(client.UpdateUser(context.TODO(), "1", &Update{}))
+	assertErrTrackFailed(client.Track(context.TODO(), "1", "name", &Event{}))
+	assertErrTrackFailed(client.Import(context.TODO(), "1", "name", &Event{}))
 }

--- a/mock.go
+++ b/mock.go
@@ -1,6 +1,7 @@
 package mixpanel
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -41,7 +42,7 @@ func (m *Mock) People(distinctId string) *MockPeople {
 	return p.(*MockPeople)
 }
 
-func (m *Mock) Track(distinctId, eventName string, e *Event) error {
+func (m *Mock) Track(_ context.Context, distinctId, eventName string, e *Event) error {
 	p := m.People(distinctId)
 	p.Events = append(p.Events, MockEvent{
 		Event: *e,
@@ -50,7 +51,7 @@ func (m *Mock) Track(distinctId, eventName string, e *Event) error {
 	return nil
 }
 
-func (m *Mock) Import(distinctId, eventName string, e *Event) error {
+func (m *Mock) Import(_ context.Context, distinctId, eventName string, e *Event) error {
 	p := m.People(distinctId)
 	p.Events = append(p.Events, MockEvent{
 		Event: *e,
@@ -95,11 +96,11 @@ func (mp *MockPeople) String() string {
 	return str
 }
 
-func (m *Mock) Update(distinctId string, u *Update) error {
-	return m.UpdateUser(distinctId, u)
+func (m *Mock) Update(ctx context.Context, distinctId string, u *Update) error {
+	return m.UpdateUser(ctx, distinctId, u)
 }
 
-func (m *Mock) UpdateUser(distinctId string, u *Update) error {
+func (m *Mock) UpdateUser(_ context.Context, distinctId string, u *Update) error {
 	p := m.People(distinctId)
 
 	if u.IP != "" {
@@ -121,19 +122,19 @@ func (m *Mock) UpdateUser(distinctId string, u *Update) error {
 	return nil
 }
 
-func (m *Mock) UnionUser(userID string, u *Update) error {
+func (m *Mock) UnionUser(_ context.Context, userID string, u *Update) error {
 	return nil
 }
 
-func (m *Mock) UpdateGroup(groupKey, groupUser string, u *Update) error {
+func (m *Mock) UpdateGroup(_ context.Context, groupKey, groupUser string, u *Update) error {
 	return nil
 }
 
-func (m *Mock) UnionGroup(groupKey, groupUser string, u *Update) error {
+func (m *Mock) UnionGroup(_ context.Context, groupKey, groupUser string, u *Update) error {
 	return nil
 }
 
-func (m *Mock) Alias(distinctId, newId string) error {
+func (m *Mock) Alias(_ context.Context, distinctId, newId string) error {
 	return nil
 }
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,6 +1,7 @@
 package mixpanel
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -12,7 +13,7 @@ func ExampleMock() {
 
 	t, _ := time.Parse(time.RFC3339, "2016-03-03T15:17:53+01:00")
 
-	client.Update("1", &Update{
+	client.Update(context.TODO(), "1", &Update{
 		Operation: "$set",
 		Timestamp: &t,
 		IP:        "127.0.0.1",
@@ -21,14 +22,14 @@ func ExampleMock() {
 		},
 	})
 
-	client.Track("1", "Sign Up", &Event{
+	client.Track(context.TODO(), "1", "Sign Up", &Event{
 		IP: "1.2.3.4",
 		Properties: map[string]interface{}{
 			"from": "email",
 		},
 	})
 
-	client.Import("1", "Sign Up", &Event{
+	client.Import(context.TODO(), "1", "Sign Up", &Event{
 		IP:        "1.2.3.4",
 		Timestamp: &t,
 		Properties: map[string]interface{}{


### PR DESCRIPTION
HTTP requests require using `context` object for controlling requests lifetime: timeouts, cancel, graceful shutdown. If calling code doesn't require context it can use a stub via `context.TODO()`